### PR TITLE
Mark any requests version greater than 2.23.x as ok

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     keywords=["stark bank", "starkbank", "sdk", "open banking", "openbanking", "banking", "open", "stark"],
     version=version,
     install_requires=[
-        "requests~=2.23.0",
+        "requests>=2.23.0",
         "starkbank-ecdsa~=1.0.0",
     ],
 )


### PR DESCRIPTION
Forçar a versão do requests aqui impede qualquer projeto utilizando a sdk de utilizar versões maiores do requests, em especial os utilizando algum gerenciador de dependências como o [poetry](https://python-poetry.org/) que não deixa passar essas divergências.

Além disso, o requests é uma das libs mais utilizadas no mundo python para realizar requisições http, com uma api considerada bem estável e que não deve quebrar de uma hora para outra.