### PR TITLE
Fix typo in README: transfer.rule as argument to Invoice is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ invoices = starkbank.invoice.create([
         interest=2.5,  # 2.5% per month
         tags=["immediate"],
         rules=[
-            starkbank.transfer.Rule(
+            starkbank.invoice.Rule(
                 key="allowedTaxIds",        # Set TaxIds allowed to receive this Invoice
                 value=[ "012.345.678-90" ]
             ) 


### PR DESCRIPTION
An Invoice accepts only `invoice.rule` properties.

In the READ, the class is initialized with a `transfer.rule` property instead.