### PR TITLE
[Fix / Boleto]: Fix missing split parameter for creating split "Boleto"

### DIFF
--- a/starkbank/boleto/__boleto.py
+++ b/starkbank/boleto/__boleto.py
@@ -1,8 +1,8 @@
 from ..utils import rest
 from starkcore.utils.api import from_api_json
+from starkcore.utils.resource import Resource
 from starkcore.utils.checks import check_date, check_datetime
 from ..split.__split import _resource as _split_resource, Split
-
 
 class Boleto(Resource):
     """# Boleto object

--- a/starkbank/boleto/__boleto.py
+++ b/starkbank/boleto/__boleto.py
@@ -1,6 +1,7 @@
 from ..utils import rest
-from starkcore.utils.resource import Resource
+from starkcore.utils.api import from_api_json
 from starkcore.utils.checks import check_date, check_datetime
+from ..split.__split import _resource as _split_resource, Split
 
 
 class Boleto(Resource):
@@ -43,7 +44,7 @@ class Boleto(Resource):
     def __init__(self, amount, name, tax_id, street_line_1, street_line_2, district, city, state_code, zip_code,
                  due=None, fine=None, interest=None, overdue_limit=None, tags=None, descriptions=None, discounts=None,
                  receiver_name=None, receiver_tax_id=None, id=None, fee=None, line=None, bar_code=None, status=None,
-                 workspace_id=None, transaction_ids=None, created=None, our_number=None):
+                 workspace_id=None, transaction_ids=None, created=None, our_number=None, splits=None):
         Resource.__init__(self, id=id)
 
         self.amount = amount
@@ -72,9 +73,21 @@ class Boleto(Resource):
         self.workspace_id = workspace_id
         self.created = check_datetime(created)
         self.our_number = our_number
+        self.splits = _parse_splits(splits)
 
 
 _resource = {"class": Boleto, "name": "Boleto"}
+
+def _parse_splits(splits):
+    if splits is None:
+        return None
+    parsed_splits = []
+    for split in splits:
+        if isinstance(split, Split):
+            parsed_splits.append(split)
+            continue
+        parsed_splits.append(from_api_json(_split_resource, split))
+    return parsed_splits
 
 
 def create(boletos, user=None):


### PR DESCRIPTION
# What does this PR do?

Fix missing parameters in Boleto entity.
> It's worth remembering that this information appears incorrectly in the documentation [HERE](https://starkbank.com/docs/api#boleto)

# What motivated the PR?

When trying to execute the `create` method from Boleto module, the error below occurred

```shell
TypeError: Boleto.__init__() got an unexpected keyword argument 'splits'
```


# How to use implemented changes

```py
boletos = starkbank.boleto.create([
    starkbank.Boleto(
        amount=400000,
        due="2020-05-20",
        name="Iron Bank S.A.",
        tax_id="20.018.183/0001-80",
        fine=2.5,
        interest=1.3,
        overdue_limit=5,
        street_line_1="Av. Faria Lima, 1844",
        street_line_2="CJ 13",
        district="Itaim Bibi",
        city="São Paulo",
        state_code="SP",
        zip_code="01500-000",
        tags=["War supply", "Invoice #1234"],
        discounts=[
            {"percentage": 10, "date": "2020-04-25"}
        ],
        
       '''
       Now Boleto class has the splits parameter
       '''
        
        splits=[
            Split(amount=3000, receiverId="5742447426535424"),
            Split(amount=5000, receiverId="5743243941642240")
        ]
    )
])
```
