### PR TITLE
Bump to v2.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Given a version number MAJOR.MINOR.PATCH, increment:
 
 
 ## [Unreleased]
+
+## [2.31.0] - 2025-09-30
 ### Changed
 - The create method from the Transaction resource is now deprecated
 ### Fixed

--- a/starkbank/__init__.py
+++ b/starkbank/__init__.py
@@ -1,4 +1,4 @@
-version = "2.30.1"
+version = "2.31.0"
 
 user = None
 language = "en-US"


### PR DESCRIPTION
### Changed
- The create method from the Transaction resource is now deprecated
### Fixed
- workspace name and username patch